### PR TITLE
Added euca-manage-imaging-stack tool

### DIFF
--- a/bin/euca-manage-imaging-stack
+++ b/bin/euca-manage-imaging-stack
@@ -1,0 +1,112 @@
+#!/usr/bin/env python
+#
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2015, Eucalyptus Systems, Inc.
+# All rights reserved.
+#
+# Redistribution and use of this software in source and binary forms, with or
+# without modification, are permitted provided that the following conditions
+# are met:
+#
+#   Redistributions of source code must retain the above
+#   copyright notice, this list of conditions and the
+#   following disclaimer.
+#
+#   Redistributions in binary form must reproduce the above
+#   copyright notice, this list of conditions and the
+#   following disclaimer in the documentation and/or other
+#   materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import sys
+import euca2ools
+import subprocess
+import os
+import argparse
+
+(major, minor, patch) = euca2ools.__version__.split('-')[0].split('.')
+if int(major) < 3 or (int(major) >= 3 and int(minor) < 1):
+    print >> sys.stderr, "euca2ools version 3.1.0 or newer required."
+    sys.exit(1)
+
+
+class ImageStackManager(object):
+
+    def __init__(self):
+        self._check_environment()
+
+    def _check_environment(self):
+        env = os.environ.copy()
+        if not "EC2_URL" in env:
+            print >> sys.stderr, "Error: Unable to find EC2_URL"
+            print >> sys.stderr, "Make sure your eucarc is sourced."
+            sys.exit(1)
+        cmd = [os.path.join(os.getenv("EUCALYPTUS", "/") + '/usr/sbin/euca-modify-property')]
+        try:
+            with open(os.devnull, 'w') as nullfile:
+                subprocess.call(cmd, env=env, stdout=nullfile)
+        except OSError:
+            print >> sys.stderr, "Error: cannot find 'euca-modify-property' binary."
+            print >> sys.stderr, "Make sure EUCALYPTUS path variable is exported."
+            sys.exit(1)
+
+    def set_property(self, value):
+
+        operation = 'enable' if value else 'disable'
+        service_property = 'services.imaging.worker.configured={0}'.format('true' if value else 'false')
+        cmd = [os.path.join(os.getenv("EUCALYPTUS", "/") + '/usr/sbin/euca-modify-property'), '-p', service_property]
+        try:
+            subprocess.check_call(cmd, env=os.environ.copy())
+        except (OSError, subprocess.CalledProcessError):
+            print >> sys.stderr, "Error: failed to {0} imaging service stack".format(operation)
+            print >> sys.stderr, "You'll have to {0} it manually.".format(operation)
+            print >> sys.stderr
+            print >> sys.stderr, "To {0} imaging service support, run this command:".format(operation)
+            print >> sys.stderr, " ".join(cmd)
+            sys.exit(1)
+
+    def enable(self):
+        self.set_property(True)
+
+    def disable(self):
+        self.set_property(False)
+
+
+if __name__ == "__main__":
+    description = '''
+    Imaging Service Stack Enable/Disable Tool:
+
+    This tool provides an easy way to create or delete stack for
+    Eucalyptus Imaging Service image.
+    '''
+    epilog = '''
+    NOTE: In order to use this you MUST have cloud administrator
+    credentials sourced in your environment (i.e., run the command
+    '. /my/cred/path/eucarc').'''
+    parser = argparse.ArgumentParser(formatter_class=argparse.RawDescriptionHelpFormatter,
+                                     description=description, epilog=epilog)
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument('-e', '--enable', action='store_true',
+                       help='Create stack for imaging service image')
+    group.add_argument('-d', '--disable', action='store_true',
+                       help='Delete stack for imaging service image')
+
+    args = parser.parse_args()
+    ism = ImageStackManager()
+
+    if args.enable:
+        ism.enable()
+    elif args.disable:
+        ism.disable()

--- a/eucalyptus-service-image.spec
+++ b/eucalyptus-service-image.spec
@@ -21,6 +21,8 @@ Source3:        %{name}.ks
 Source4:        euca-describe-service-images
 # Install tool
 Source5:        euca-install-service-image
+# Manage imaging stack tool
+Source6:        euca-manage-imaging-stack
 
 # BuildRequires:  euca2ools >= 3.2
 
@@ -51,6 +53,7 @@ install -m 644 %{SOURCE0} $RPM_BUILD_ROOT/usr/share/eucalyptus/service-images/%{
 install -m 755 -d $RPM_BUILD_ROOT/usr/bin
 install -m 755 %{SOURCE4} $RPM_BUILD_ROOT/usr/bin
 install -m 755 %{SOURCE5} $RPM_BUILD_ROOT/usr/bin
+install -m 755 %{SOURCE6} $RPM_BUILD_ROOT/usr/bin
 
 
 %files
@@ -61,7 +64,10 @@ install -m 755 %{SOURCE5} $RPM_BUILD_ROOT/usr/bin
 /usr/share/eucalyptus/service-images/%{name}.tgz
 /usr/bin/euca-describe-service-images
 /usr/bin/euca-install-service-image
+/usr/bin/euca-manage-imaging-stack
 
 %changelog
-* Fri Dec 05 2014 Eucalyptus Release Engineering <support@eucalyptus.com> - 0.1-0
+* Thu Apr 23 2015 Eucalyptus Release Engineering <support@eucalyptus.com>
+- Added euca-manage-imaging-stack
+* Fri Dec 05 2014 Eucalyptus Release Engineering <support@eucalyptus.com>
 - Created


### PR DESCRIPTION
How about one tool to create/delete stack for code reuse? It can be renamed to euca-manage-service-stack and invoked with extra parameter -s <stack_name>. Right now it triggers imaging worker stack creation.
