### PR TITLE
Allow to ovewrite version at install

### DIFF
--- a/bin/esi-install-image
+++ b/bin/esi-install-image
@@ -131,12 +131,12 @@ class ServiceImageManager(object):
 
     def install(self, tarball, version=None):
         ### Decompress image
-        decompress_cmd = "/bin/tar xJf {0}".format(tarball)
+        decompress_cmd = "/bin/tar vxJf {0}".format(tarball)
         print "Decompressing tarball: " + tarball
         decompress_stdout, decompress_stderr = self._run_command(decompress_cmd)
         ### Bundle and upload image
         image_file = decompress_stdout.strip()
-
+        print "Installing image from {0}".format(image_file)
         version_string = self._get_image_version() if version is None \
             else "0.{0}".format(version)
         bucket = self.IMAGE_NAME + '-' + version_string
@@ -239,7 +239,7 @@ if __name__ == "__main__":
     ism = ServiceImageManager.create()
 
     if args.tarball:
-        ism.install(args.tarball)
+        ism.install(args.tarball, args.set_version if args.set_version is not None else None)
     elif args.install_default:
         print 'Installing Service Image...'
         try:

--- a/bin/esi-install-image
+++ b/bin/esi-install-image
@@ -239,7 +239,7 @@ if __name__ == "__main__":
     ism = ServiceImageManager.create()
 
     if args.tarball:
-        ism.install(args.tarball, args.set_version if args.set_version is not None else None)
+        ism.install(args.tarball, args.set_version)
     elif args.install_default:
         print 'Installing Service Image...'
         try:

--- a/bin/esi-install-image
+++ b/bin/esi-install-image
@@ -212,8 +212,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(formatter_class=argparse.RawDescriptionHelpFormatter,
                                      description=description, epilog=epilog)
     group = parser.add_mutually_exclusive_group(required=True)
-    group.add_argument('-t', '--tarball', metavar='TARBALL',
-                       help='Service tarball to install')
+    group.add_argument('-t', '--tarball', metavar='TARBALL', help=argparse.SUPPRESS)
     group.add_argument('--install-default', action='store_true',
                        help='''This option must be supplied if you
                        would like to install the default tarball''')
@@ -230,8 +229,7 @@ if __name__ == "__main__":
     parser.add_argument('--force', action='store_true', help='''Force
                         an operation. This will force removal of
                         enabled Service images.''')
-    parser.add_argument('--set-version', help='''Overwrites image version
-                        with provided value. Please use it careful''')
+    parser.add_argument('--force-version', help=argparse.SUPPRESS)
 
 
 
@@ -239,7 +237,7 @@ if __name__ == "__main__":
     ism = ServiceImageManager.create()
 
     if args.tarball:
-        ism.install(args.tarball, args.set_version)
+        ism.install(args.tarball, args.force_version)
     elif args.install_default:
         print 'Installing Service Image...'
         try:

--- a/bin/esi-install-image
+++ b/bin/esi-install-image
@@ -129,7 +129,7 @@ class ServiceImageManager(object):
         for package in matches:
             return package['version']
 
-    def install(self, tarball):
+    def install(self, tarball, version=None):
         ### Decompress image
         decompress_cmd = "/bin/tar xJf {0}".format(tarball)
         print "Decompressing tarball: " + tarball
@@ -137,7 +137,8 @@ class ServiceImageManager(object):
         ### Bundle and upload image
         image_file = decompress_stdout.strip()
 
-        version_string = self._get_image_version()
+        version_string = self._get_image_version() if version is None \
+            else "0.{0}".format(version)
         bucket = self.IMAGE_NAME + '-' + version_string
         image_name = "{0}-v{1}".format(self.IMAGE_NAME, version_string)
         print "Bundling, uploading and registering image to bucket: " + bucket
@@ -229,6 +230,10 @@ if __name__ == "__main__":
     parser.add_argument('--force', action='store_true', help='''Force
                         an operation. This will force removal of
                         enabled Service images.''')
+    parser.add_argument('--set-version', help='''Overwrites image version
+                        with provided value. Please use it careful''')
+
+
 
     args = parser.parse_args()
     ism = ServiceImageManager.create()

--- a/esitoolsupport/__init__.py
+++ b/esitoolsupport/__init__.py
@@ -50,7 +50,7 @@ def _check_binary(binary):
         with open(os.devnull, 'w') as nullfile:
             subprocess.call(binary, env=os.environ.copy(), stdout=nullfile)
     except OSError:
-        print >> sys.stderr, "Error: cannot find '{0}' binary.".format(binary)
+        print >> sys.stderr, "Error: cannot execute '{0}' binary.".format(" ".join(binary))
         print >> sys.stderr, "Make sure EUCALYPTUS path variable is exported."
         sys.exit(1)
 
@@ -68,7 +68,7 @@ def check_environment():
         print >> sys.stderr, "Error: Unable to find EC2_URL"
         print >> sys.stderr, "Make sure your eucarc is sourced."
         sys.exit(1)
-    for b in ['/usr/bin/euare-accountlist', '/usr/bin/euctl']:
+    for b in [['/usr/bin/euare-accountlist'], ['/usr/bin/euctl', '-U', _get_properties_url()]]:
         _check_binary(b)
 
 


### PR DESCRIPTION
This way -t (tarball) option can be used without collisions.

Fixes for: EUCA-11255
