### PR TITLE
kickstart and esi-install-image updates for centos 7

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -29,7 +29,7 @@ build/image/eucalyptus-service-image.raw: eucalyptus-service-image.ks
 		--initrd-inject $< \
 		--extra-args ks="file:/$< console=tty0 console=ttyS0,115200 serial" \
 		--location @INSTALL_TREE@ \
-		--disk $@,size=$(DISK) \
+		--disk $@,format=raw,size=$(DISK) \
 		--vcpus $(CPUS) --ram $(MEMORY) \
 		--graphics none \
 		--hvm --accelerate --noreboot \

--- a/bin/esi-install-image
+++ b/bin/esi-install-image
@@ -157,6 +157,23 @@ class ServiceImageManager(EsiBase):
         decompress_stdout, decompress_stderr = self._run_command(['/bin/tar', 'vxJf', tarball])
         ### Bundle and upload image
         image_file = decompress_stdout.strip()
+        ### Verify the image is raw vs. qcow2
+        try:
+            cmd = ['/usr/bin/file', image_file]
+            qemu_stdout, qemu_stderr = self._run_command(cmd, self._debug)
+            search_qcow = re.search(r'qcow image', qemu_stdout, re.I)
+            if search_qcow:
+                print "The image is formatted as QCOW, converting to raw"
+                try:
+                    cmd = ['/usr/bin/qemu-img', 'convert', '-O', 'raw', image_file,
+                           image_file + '.tmp']
+                    convert_stdout, convert_stderr = self._run_command(cmd, self._debug)
+                    os.rename(image_file + '.tmp', image_file)
+                except Exception:
+                    print "Error: got exception converting image"
+                    exit(1)
+        except:
+            pass
         print "Installing image from {0}".format(image_file)
         print "Bundling, uploading and registering image to bucket: " + image_name
         cmd = ['euca-install-image',

--- a/bin/esi-install-image
+++ b/bin/esi-install-image
@@ -157,23 +157,6 @@ class ServiceImageManager(EsiBase):
         decompress_stdout, decompress_stderr = self._run_command(['/bin/tar', 'vxJf', tarball])
         ### Bundle and upload image
         image_file = decompress_stdout.strip()
-        ### Verify the image is raw vs. qcow2
-        try:
-            cmd = ['/usr/bin/file', image_file]
-            qemu_stdout, qemu_stderr = self._run_command(cmd, self._debug)
-            search_qcow = re.search(r'qcow image', qemu_stdout, re.I)
-            if search_qcow:
-                print "The image is formatted as QCOW, converting to raw"
-                try:
-                    cmd = ['/usr/bin/qemu-img', 'convert', '-O', 'raw', image_file,
-                           image_file + '.tmp']
-                    convert_stdout, convert_stderr = self._run_command(cmd, self._debug)
-                    os.rename(image_file + '.tmp', image_file)
-                except Exception:
-                    print "Error: got exception converting image"
-                    exit(1)
-        except:
-            pass
         print "Installing image from {0}".format(image_file)
         print "Bundling, uploading and registering image to bucket: " + image_name
         cmd = ['euca-install-image',

--- a/eucalyptus-service-image.ks.in
+++ b/eucalyptus-service-image.ks.in
@@ -4,25 +4,26 @@ reboot
 keyboard us
 lang en_US.UTF-8
 timezone UTC
-network --bootproto=dhcp --device=eth0 --onboot yes
+network --bootproto dhcp --device eth0 --onboot on
 rootpw --iscrypted $1$HEVobWzu$6d5IWr.r7Df15XHLFCggW/
 auth --useshadow --passalgo=sha512
 firewall --disabled
 selinux --disabled
 services --enabled=network,ntpd,ntpdate
 skipx
+eula --agreed
 bootloader --timeout=1 --append="xen_blkfront.sda_is_xvda=1 serial=tty0 console=ttyS0,115200n8"
 clearpart --all
 zerombr
 part / --size 1536 --grow --fstype ext3
 
-url --url=@INSTALL_TREE@
+url --url @INSTALL_TREE@
 repo --name updates --baseurl=@UPDATES_MIRROR@
 repo --name epel --baseurl=@EPEL_MIRROR@
 repo --name eucalyptus --baseurl=@EUCALYPTUS_MIRROR@
 
 # Add all the packages after the base packages
-%packages --nobase --excludedocs --instLangs=en
+%packages --excludedocs --instLangs=en
 @core
 audit
 bash
@@ -105,10 +106,6 @@ sed -i 's/gecos: Fedora Cloud User/gecos: Cloud User/' /etc/cloud/cloud.cfg
 # Configure networking
 echo "NOZEROCONF=yes" >> /etc/sysconfig/network
 echo "NETWORKING=yes" >> /etc/sysconfig/network
-
-# Lock root login
-# future versions of anaconda have ``rootpw --lock''
-passwd -l root
 
 # Configure sshd
 sed -i 's/PasswordAuthentication yes/PasswordAuthentication no/' /etc/ssh/sshd_config


### PR DESCRIPTION
Minor CentOS 7 updates to kickstart file

In addition to minor nitpick updates, we also remove the
root password lock because cloud-init provides this already

Produce raw image format from virt-install command
